### PR TITLE
Remove duplicate get_logger import

### DIFF
--- a/main_SuperOpsTickets_import.py
+++ b/main_SuperOpsTickets_import.py
@@ -5,7 +5,6 @@ from bs4 import BeautifulSoup  # Import BeautifulSoup for HTML stripping
 from syncro_configs import get_logger  # Import logger function
 from syncro_read import get_all_tickets_for_customer, extract_ticket_subjects_and_dates
 from syncro_utils import get_customer_id_by_name, get_syncro_created_date
-from syncro_configs import get_logger  # Centralized logger import
 from syncro_utils import syncro_prepare_ticket_json_superops, build_syncro_comment
 from syncro_write import syncro_create_ticket, syncro_create_comment
 from datetime import datetime


### PR DESCRIPTION
## Summary
- remove second `get_logger` import in `main_SuperOpsTickets_import.py`

## Testing
- `python -m py_compile main_SuperOpsTickets_import.py`
- `python - <<'PY'
import main_SuperOpsTickets_import as m
print('logger', m.logger)
PY`


------
https://chatgpt.com/codex/tasks/task_e_68a3867e4ce483219c0eab37b1be10cc