### PR TITLE
Handle missing content in HTML stripping

### DIFF
--- a/main_SuperOpsTickets_import.py
+++ b/main_SuperOpsTickets_import.py
@@ -54,7 +54,12 @@ def make_api_call(query, variables=None):
 
 # Function to strip HTML content
 def strip_html(content):
-    """Strips HTML tags and returns plain text."""
+    """Strips HTML tags and returns plain text.
+
+    Returns an empty string when content is missing.
+    """
+    if not content:
+        return ""
     soup = BeautifulSoup(content, "html.parser")
     return soup.get_text()
 


### PR DESCRIPTION
## Summary
- ensure `strip_html` returns an empty string when content is missing
- document that empty strings are returned for missing content

## Testing
- `python -m py_compile main_SuperOpsTickets_import.py`


------
https://chatgpt.com/codex/tasks/task_e_68a38763d21c8321a093905148332b40