### PR TITLE
Add configurable API rate limit

### DIFF
--- a/main_SuperOpsTickets_import.py
+++ b/main_SuperOpsTickets_import.py
@@ -2,7 +2,7 @@ import requests
 import time
 from pprint import pprint
 from bs4 import BeautifulSoup  # Import BeautifulSoup for HTML stripping
-from syncro_configs import get_logger  # Import logger function
+from syncro_configs import get_logger, RATE_LIMIT_SECONDS  # Import logger and rate limit
 from syncro_read import get_all_tickets_for_customer, extract_ticket_subjects_and_dates
 from syncro_utils import get_customer_id_by_name, get_syncro_created_date
 from syncro_utils import syncro_prepare_ticket_json_superops, build_syncro_comment
@@ -39,7 +39,7 @@ QUERY_GET_TICKET_NOTES = """query getTicketNoteList($input: TicketIdentifierInpu
 
 # Function to make API calls
 def make_api_call(query, variables=None):
-    time.sleep(.35) 
+    time.sleep(RATE_LIMIT_SECONDS)
     """Generic function to make GraphQL requests to SuperOps API"""
     payload = {"query": query, "variables": variables or {}}
 

--- a/syncro_configs.py
+++ b/syncro_configs.py
@@ -14,6 +14,9 @@ SYNCRO_API_KEY = "your_api_key"
 
 SYNCRO_API_BASE_URL = f"https://{SYNCRO_SUBDOMAIN}.syncromsp.com/api/v1"
 
+# Rate limiting configuration
+RATE_LIMIT_SECONDS = 0.5
+
 # Logging Configuration
 LOG_DIR = os.path.abspath(os.path.join(os.path.dirname(__file__), "logs"))
 os.makedirs(LOG_DIR, exist_ok=True)

--- a/syncro_read.py
+++ b/syncro_read.py
@@ -16,7 +16,7 @@ parent_dir = os.path.abspath(os.path.join(os.path.dirname(__file__), '..'))
 sys.path.insert(0, parent_dir)
 
 # Import from syncro_config and utils
-from syncro_configs import SYNCRO_API_BASE_URL, SYNCRO_API_KEY, get_logger
+from syncro_configs import SYNCRO_API_BASE_URL, SYNCRO_API_KEY, get_logger, RATE_LIMIT_SECONDS
 from syncro_utils import syncro_api_call
 
 # Get a logger for this module
@@ -58,7 +58,7 @@ def syncro_api_get(endpoint: str, params: dict = None):
         params["page"] = current_page
 
         response = syncro_api_call("GET", endpoint, params=params)
-        time.sleep(0.5)
+        time.sleep(RATE_LIMIT_SECONDS)
         if not response:
             logger.error(f"Failed to fetch data from {endpoint}. Stopping pagination.")
             break

--- a/syncro_utils.py
+++ b/syncro_utils.py
@@ -9,7 +9,7 @@ import logging
 import time
 from typing import Any, Dict, List
 import csv
-from syncro_configs import SYNCRO_API_BASE_URL, SYNCRO_API_KEY, get_logger, TEMP_FILE_PATH
+from syncro_configs import SYNCRO_API_BASE_URL, SYNCRO_API_KEY, get_logger, TEMP_FILE_PATH, RATE_LIMIT_SECONDS
 
 import logging
 import re
@@ -166,7 +166,7 @@ def syncro_api_call(method: str, endpoint: str, data: dict = None, params: dict 
 
     try:
         response = requests.request(method, url, headers=headers, json=data, params=params)
-        time.sleep(0.5)
+        time.sleep(RATE_LIMIT_SECONDS)
         response.raise_for_status()  # Raise HTTPError for bad responses
         return response.json() if response.content else {}
     except requests.HTTPError as http_err:


### PR DESCRIPTION
## Summary
- Add `RATE_LIMIT_SECONDS` setting in `syncro_configs` (default 0.5 seconds)
- Replace hard-coded `time.sleep` calls with `RATE_LIMIT_SECONDS` in main import, read, and util modules

## Testing
- `python -m py_compile main_SuperOpsTickets_import.py syncro_configs.py syncro_utils.py syncro_read.py`


------
https://chatgpt.com/codex/tasks/task_e_68a3877dc048832180997932d0619c47