### PR TITLE
Replace handler prints with debug logging

### DIFF
--- a/syncro_read.py
+++ b/syncro_read.py
@@ -21,8 +21,8 @@ from syncro_utils import syncro_api_call
 
 # Get a logger for this module
 logger = get_logger(__name__)
-print(f"Handlers for {logger.name}: {logger.handlers}")
-print(f"Handlers for root logger: {logging.getLogger().handlers}")
+logger.debug(f"Handlers for {logger.name}: {logger.handlers}")
+logger.debug(f"Handlers for root logger: {logging.getLogger().handlers}")
 
 _api_call_count = 0
 

--- a/syncro_utils.py
+++ b/syncro_utils.py
@@ -92,8 +92,8 @@ sys.path.insert(0, parent_dir)
 
 # Get a logger for this module
 logger = get_logger(__name__)
-print(f"Handlers for {logger.name}: {logger.handlers}")
-print(f"Handlers for root logger: {logging.getLogger().handlers}")
+logger.debug(f"Handlers for {logger.name}: {logger.handlers}")
+logger.debug(f"Handlers for root logger: {logging.getLogger().handlers}")
 
 def get_customer_id_by_name(customer_name: str):#, logger: logging.Logger) -> int:
     """

--- a/syncro_write.py
+++ b/syncro_write.py
@@ -13,8 +13,8 @@ sys.path.insert(0, parent_dir)
 
 # Get a logger for this module
 logger = get_logger(__name__)
-print(f"Handlers for {logger.name}: {logger.handlers}")
-print(f"Handlers for root logger: {logging.getLogger().handlers}")
+logger.debug(f"Handlers for {logger.name}: {logger.handlers}")
+logger.debug(f"Handlers for root logger: {logging.getLogger().handlers}")
 
 def syncro_create_customer(customer_data: dict):
     """


### PR DESCRIPTION
## Summary
- Replace debugging `print` statements in syncro_write.py, syncro_utils.py, and syncro_read.py with `logger.debug`

## Testing
- `python -m py_compile syncro_write.py syncro_utils.py syncro_read.py`


------
https://chatgpt.com/codex/tasks/task_e_68a387ac547083219323949af9fcb525