### PR TITLE
Select earliest tech reply in SuperOps import

### DIFF
--- a/main_SuperOpsTickets_import.py
+++ b/main_SuperOpsTickets_import.py
@@ -93,7 +93,7 @@ def get_assigned_tech_and_user(conversations):
         tech_replies = [conv for conv in conversations if conv.get('type') == 'TECH_REPLY']
 
         if tech_replies:
-            oldest_tech_reply = max(tech_replies, key=lambda x: x['time'])  # Find oldest TECH_REPLY
+            oldest_tech_reply = min(tech_replies, key=lambda x: x['time'])  # Find oldest TECH_REPLY
             tech = oldest_tech_reply.get('user', None)  # Get the technician's info
             to_users = oldest_tech_reply.get("toUsers", [])  # Get the toUsers list
             

--- a/tests/test_get_assigned_tech_and_user.py
+++ b/tests/test_get_assigned_tech_and_user.py
@@ -1,0 +1,30 @@
+from main_SuperOpsTickets_import import get_assigned_tech_and_user
+
+
+def test_earliest_tech_reply_is_chosen():
+    conversations = [
+        {
+            "type": "CUSTOMER_REPLY",
+            "time": 0,
+            "user": {"name": "Customer"},
+            "toUsers": [{"user": "Tech"}],
+        },
+        {
+            "type": "TECH_REPLY",
+            "time": 2,
+            "user": {"name": "Tech2"},
+            "toUsers": [{"user": "User2"}],
+        },
+        {
+            "type": "TECH_REPLY",
+            "time": 1,
+            "user": {"name": "Tech1"},
+            "toUsers": [{"user": "User1"}],
+        },
+    ]
+
+    tech, to_users = get_assigned_tech_and_user(conversations)
+
+    assert tech["name"] == "Tech1"
+    assert to_users == [{"user": "User1"}]
+


### PR DESCRIPTION
## Summary
- choose earliest TECH_REPLY conversation rather than latest
- test that get_assigned_tech_and_user returns the earliest reply

## Testing
- `python -m pytest tests/test_get_assigned_tech_and_user.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68a387768d908321a56779c5086b6550