### PR TITLE
Add option to auto-create missing customers

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,8 +6,11 @@
    - Add your **Syncro Subdomain** and **API Key** in the `syncro_configs` file.
    - Adjust your Timezone if needed
 
-1b. **Configure SuperOps API Access**  
+1b. **Configure SuperOps API Access**
     - the fields are API_KEY and CUSTOMER_SUBDOMAIN located at the top of main_SuperOpsTickets_import.py file
+
+1c. **Configure Import Options**
+   - In `syncro_configs.py`, set `CREATE_MISSING_CUSTOMERS = True` to automatically create a Syncro customer when none is found.
 
 
 2. **Import Process & Temporary Data**  

--- a/syncro_configs.py
+++ b/syncro_configs.py
@@ -14,6 +14,9 @@ SYNCRO_API_KEY = "your_api_key"
 
 SYNCRO_API_BASE_URL = f"https://{SYNCRO_SUBDOMAIN}.syncromsp.com/api/v1"
 
+# Optional runtime configuration
+CREATE_MISSING_CUSTOMERS = False  # Set to True to create missing customers during import
+
 # Logging Configuration
 LOG_DIR = os.path.abspath(os.path.join(os.path.dirname(__file__), "logs"))
 os.makedirs(LOG_DIR, exist_ok=True)


### PR DESCRIPTION
## Summary
- manage `CREATE_MISSING_CUSTOMERS` directly in `syncro_configs.py`
- update README to document the flag
- remove unused `configs.json`

## Testing
- `python -m py_compile syncro_configs.py main_SuperOpsTickets_import.py`


------
https://chatgpt.com/codex/tasks/task_e_68a386c413b883218f6786975ea1e874