### PR TITLE
Force resolved status and align initial issue timestamp

### DIFF
--- a/main_SuperOpsTickets_import.py
+++ b/main_SuperOpsTickets_import.py
@@ -472,7 +472,8 @@ def process_individual_ticket(client, ticket_id, ticket_info, matched_ticket_ids
             return
 
         converted_created_time = get_syncro_created_date(created_time)
-        status = ticket_info.get("status", "Unknown")
+        # Force imported tickets to have a Resolved status in Syncro
+        status = "Resolved"
         priority = ticket_info.get("priority", "Unknown")
         assigned_tech = extract_assigned_tech(ticket_id, ticket_info)
         description = ticket_info.get("description", "No description available.")

--- a/syncro_utils.py
+++ b/syncro_utils.py
@@ -444,13 +444,14 @@ def get_syncro_tech(tech_name: str):
 
 
 
-def build_syncro_initial_issue(initial_issue: str, syncroContact: str) -> list:
+def build_syncro_initial_issue(initial_issue: str, syncroContact: str, created_at: str) -> list:
     """
     Build the JSON object for the initial issue in Syncro.
 
     Args:
         initial_issue (str): The issue description.
         syncroContact (str): The Syncro contact associated with the issue.
+        created_at (str): Timestamp for the initial issue comment.
 
     Returns:
         list: A list representing the comments for the initial issue.
@@ -489,7 +490,8 @@ def build_syncro_initial_issue(initial_issue: str, syncroContact: str) -> list:
                 "body": initial_issue,
                 "hidden": True,
                 "do_not_email": True,
-                "tech": syncroContact
+                "tech": syncroContact,
+                "created_at": created_at
             }
         ]
 
@@ -947,7 +949,7 @@ def syncro_prepare_ticket_json_superops(client, contact, ticket_id, subject, con
     syncro_tech = get_syncro_tech(tech)
     syncro_created_date = get_syncro_created_date(created)
     syncro_contact = get_syncro_customer_contact(customer_id, contact)
-    initial_issue_comments = build_syncro_initial_issue(initial_issue, contact)    
+    initial_issue_comments = build_syncro_initial_issue(initial_issue, contact, syncro_created_date)
     syncro_priority = get_syncro_priority(priority)
 
     # Create JSON payload
@@ -997,7 +999,7 @@ def syncro_prepare_ticket_json(ticket):
     syncro_tech = get_syncro_tech(tech)
     syncro_created_date = get_syncro_created_date(created)
     syncro_contact = get_syncro_customer_contact(customer_id, contact)
-    initial_issue_comments = build_syncro_initial_issue(initial_issue, contact)
+    initial_issue_comments = build_syncro_initial_issue(initial_issue, contact, syncro_created_date)
     syncro_issue_type = get_syncro_issue_type(issue_type)
     syncro_priority = get_syncro_priority(priority)
 


### PR DESCRIPTION
## Summary
- Always mark imported tickets as Resolved when creating them in Syncro
- Stamp the initial issue comment with the ticket's creation time

## Testing
- `PYTHONPATH=. pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a76e8030f48321a740efb5b6084c27